### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/example.js
+++ b/example.js
@@ -1,6 +1,7 @@
-var HaProxy = require("github.com/quilt/haproxy").Haproxy;
-var Mongo = require("github.com/quilt/mongo");
-var Node = require("github.com/quilt/nodejs");
+const {createDeployment, Machine, Range, githubKeys, LabelRule} = require("@quilt/quilt");
+var HaProxy = require("@quilt/haproxy").Haproxy;
+var Mongo = require("@quilt/mongo");
+var Node = require("@quilt/nodejs");
 
 // AWS
 var namespace = createDeployment({});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@quilt/mean",
+  "version": "0.0.1",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt",
+    "@quilt/mongo": "quilt/mongo",
+    "@quilt/nodejs": "quilt/nodejs",
+    "@quilt/haproxy": "quilt/haproxy"
+  }
+}


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.