### PR TITLE
blueprint: Remove use of infrastructure.deploy()

### DIFF
--- a/mean.js
+++ b/mean.js
@@ -21,7 +21,9 @@ function Mean(count, nodeRepo) {
   this.proxy.allowFrom(publicInternet, haproxy.exposedPort);
 
   this.deploy = function deploy(deployment) {
-    deployment.deploy([this.app, this.mongo, this.proxy]);
+    this.app.deploy(deployment);
+    this.mongo.deploy(deployment);
+    this.proxy.deploy(deployment);
   };
 }
 

--- a/meanExample.js
+++ b/meanExample.js
@@ -20,4 +20,4 @@ infrastructure.deploy(machine.asWorker().replicate(count));
 
 const nodeRepository = 'https://github.com/quilt/node-todo.git';
 const mean = new Mean(count, nodeRepository);
-infrastructure.deploy(mean);
+mean.deploy(infrastructure);


### PR DESCRIPTION
Instead, we should call deploy() directly on the underlying
Container/LoadBalancer/Application/etc.