### PR TITLE
blueprint: Update to use new Node.js API

### DIFF
--- a/mean.js
+++ b/mean.js
@@ -15,9 +15,9 @@ function Mean(count, nodeRepo) {
     },
   });
 
-  this.proxy = haproxy.simpleLoadBalancer(this.app.cluster);
+  this.proxy = haproxy.simpleLoadBalancer(this.app.containers);
 
-  this.mongo.allowFrom(this.app.cluster, this.mongo.port);
+  this.mongo.allowFrom(this.app.containers, this.mongo.port);
   this.proxy.allowFrom(publicInternet, haproxy.exposedPort);
 
   this.deploy = function deploy(deployment) {


### PR DESCRIPTION
The node.js blueprint renamed cluster to containers;
this commit updates the MEAN blueprint to use the new
variable name.